### PR TITLE
Use cobra command for argument handling

### DIFF
--- a/cmd/git-lzc/lzc.go
+++ b/cmd/git-lzc/lzc.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	lazycommit "github.com/spenserblack/git-lazy-commit"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "git-lzc",
+	Short: "Lazy Commit generates commit messages for you",
+	Long: `Lazy Commit checks your git status, stages files if they're all unstaged,
+				and generates a commit message for you.`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		repo := lazycommit.Repo(".")
+
+		noStaged, err := repo.NoStaged()
+		onError(err)
+
+		if noStaged {
+			onError(repo.StageAll())
+		}
+
+		out, err := repo.Commit()
+		onError(err)
+
+		fmt.Printf("%s", out)
+	},
+	SilenceUsage: true,
+}

--- a/cmd/git-lzc/main.go
+++ b/cmd/git-lzc/main.go
@@ -3,24 +3,13 @@ package main
 import (
 	"fmt"
 	"os"
-
-	lazycommit "github.com/spenserblack/git-lazy-commit"
 )
 
 func main() {
-	repo := lazycommit.Repo(".")
-
-	noStaged, err := repo.NoStaged()
-	onError(err)
-
-	if noStaged {
-		onError(repo.StageAll())
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
-
-	out, err := repo.Commit()
-	onError(err)
-
-	fmt.Printf("%s", out)
 }
 
 func onError(err error) {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,12 @@ module github.com/spenserblack/git-lazy-commit
 
 go 1.20
 
-require github.com/cli/safeexec v1.0.1
+require (
+	github.com/cli/safeexec v1.0.1
+	github.com/spf13/cobra v1.6.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
 github.com/cli/safeexec v1.0.1 h1:e/C79PbXF4yYTN/wauC4tviMxEV13BwljGj0N9j+N00=
 github.com/cli/safeexec v1.0.1/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
While this doesn't add any options or arguments, it does set up the
command to recognize them. Specifically, that it shouldn't receive
any arguments or options.

This results in an error message when a user executes the command with
additional arguments or options, so that usage like
`git lzc --version` won't result in the executable surprisingly
generating a commit.

Fixes #10